### PR TITLE
Add trees for TWRP

### DIFF
--- a/twrp.xml
+++ b/twrp.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+	<project path="bootable/recovery-twrp" name="omnirom/android_bootable_recovery" remote="github" revision="android-7.1" groups="pdk-cw-fs"/>
+	<project path="external/busybox" name="LineageOS/android_external_busybox" revision="cm-14.1" />
+
+</manifest>


### PR DESCRIPTION
This adds a manifest with the TWRP tree, so that it can be built in LOS.
Check the PRs in https://github.com/IDOL-3/android_device_alcatel_idol3 for the changes needed in the device tree.